### PR TITLE
fix(nix-closure-graph): `nix path-info` format

### DIFF
--- a/programs/nix-closure-graph/lib.jq
+++ b/programs/nix-closure-graph/lib.jq
@@ -26,3 +26,13 @@ def size_pretty:
 def formatTime:
     . | strftime("%F %T UTC")
     ;
+
+# Converts a `{path_a: value_a, ...}` into `[{...value_a, path: path_a}, ...]` if needed.
+# Before https://github.com/NixOS/nix/pull/9242, `nix path-info` used to return an array, now it returns an object.
+def entries_to_array:
+    if type == "array" then
+        .
+    else
+        to_entries | map(.value + {path: .key})
+    end
+    ;

--- a/programs/nix-closure-graph/nix-path-info-graphviz.jq
+++ b/programs/nix-closure-graph/nix-path-info-graphviz.jq
@@ -27,6 +27,6 @@ def graphnode:
     ;
 
 "digraph G {\n",
-(.[] | (graphnode, graphedge)),
+  (lib::entries_to_array | .[] | (graphnode, graphedge)),
 "}"
 

--- a/programs/nix-closure-graph/nix-path-info-lg.jq
+++ b/programs/nix-closure-graph/nix-path-info-lg.jq
@@ -33,7 +33,7 @@ def graphnode:
     }
     ;
 
-
+lib::entries_to_array |
 (reduce .[] as $inp (({nodes: {}, edges: []});
     {
         nodes: (.nodes * {($inp.path): ($inp | graphnode)}),


### PR DESCRIPTION
Hi, the other day I wanted to use your `nix-closure-graph` script (which I find super useful!).
I noticed it was failing as described in #12.

This PR adds a small JQ helper function to adapt the format if needed.

Fixes #12