### PR TITLE
buck2.nvim: create `buck2.setup()` function for `lazy.nvim`

### DIFF
--- a/vim-plugins/buck2.nvim/README.md
+++ b/vim-plugins/buck2.nvim/README.md
@@ -2,6 +2,22 @@
 
 [buck2] integration for neovim.
 
+Quick start with [lazy.nvim][lazy]:
+
+```lua
+require("lazy").setup {
+  {
+    "nvim-lua/plenary.nvim",
+    lazy = true,
+  },
+  {
+    "lf-/buck2.nvim",
+  },
+}
+```
+
+[lazy]: https://github.com/folke/lazy.nvim
+
 ## What's in here
 
 - Open Buck files corresponding to a target with `:BuckOpen`

--- a/vim-plugins/buck2.nvim/lua/jade/buck2.lua
+++ b/vim-plugins/buck2.nvim/lua/jade/buck2.lua
@@ -1,36 +1,41 @@
-local Job = require('plenary.job')
+local Job = require("plenary.job")
 local M = {}
 
 local function err_log(...)
-    vim.schedule_wrap(function(...)
-        vim.api.nvim_err_writeln(table.concat({ ... }, ' '))
-    end)(...)
+	vim.schedule_wrap(function(...)
+		vim.api.nvim_err_writeln(table.concat({ ... }, " "))
+	end)(...)
 end
 
 --- @param cmd table<string>
 --- @param on_result any completion callback
 function M.buck2(cmd, on_result)
-    local new_cmd = { '-v0', unpack(cmd) }
-    return Job:new {
-        command = "buck2",
-        args = new_cmd,
-        enable_recording = true,
-        on_exit = function(j, return_val)
-            if return_val ~= 0 then
-                err_log('buck2 failed:\ncommand: buck2',
-                    table.concat(new_cmd, ' '), '\noutput:',
-                    table.concat(j:stderr_result(), '\n'))
-                return
-            end
-            if on_result then on_result(j) end
-        end,
-    }
+	local new_cmd = { "-v0", unpack(cmd) }
+	return Job:new({
+		command = "buck2",
+		args = new_cmd,
+		enable_recording = true,
+		on_exit = function(j, return_val)
+			if return_val ~= 0 then
+				err_log(
+					"buck2 failed:\ncommand: buck2",
+					table.concat(new_cmd, " "),
+					"\noutput:",
+					table.concat(j:stderr_result(), "\n")
+				)
+				return
+			end
+			if on_result then
+				on_result(j)
+			end
+		end,
+	})
 end
 
 --- Runs a uquery command with the given query.
 --- @param query string
 function M.uquery(query)
-    return M.buck2({ 'uquery', '--console', 'simple', '--', query }):sync(4000)
+	return M.buck2({ "uquery", "--console", "simple", "--", query }):sync(4000)
 end
 
 return M

--- a/vim-plugins/buck2.nvim/lua/jade/buck2.lua
+++ b/vim-plugins/buck2.nvim/lua/jade/buck2.lua
@@ -1,12 +1,6 @@
 local Job = require("plenary.job")
 local M = {}
 
-local function err_log(...)
-	vim.schedule_wrap(function(...)
-		vim.api.nvim_err_writeln(table.concat({ ... }, " "))
-	end)(...)
-end
-
 --- @param cmd table<string>
 --- @param on_result any completion callback
 function M.buck2(cmd, on_result)
@@ -17,11 +11,12 @@ function M.buck2(cmd, on_result)
 		enable_recording = true,
 		on_exit = function(j, return_val)
 			if return_val ~= 0 then
-				err_log(
-					"buck2 failed:\ncommand: buck2",
-					table.concat(new_cmd, " "),
-					"\noutput:",
-					table.concat(j:stderr_result(), "\n")
+				vim.notify(
+					"buck2 failed:\ncommand: buck2 "
+						.. table.concat(new_cmd, " ")
+						.. "\noutput:"
+						.. table.concat(j:stderr_result(), "\n"),
+					vim.log.levels.ERROR
 				)
 				return
 			end

--- a/vim-plugins/buck2.nvim/lua/jade/buck2.lua
+++ b/vim-plugins/buck2.nvim/lua/jade/buck2.lua
@@ -2,7 +2,8 @@ local Job = require("plenary.job")
 local M = {}
 
 --- @param cmd table<string>
---- @param on_result any completion callback
+--- @param on_result? fun(job: Job) completion callback
+--- @return Job
 function M.buck2(cmd, on_result)
 	local new_cmd = { "-v0", unpack(cmd) }
 	return Job:new({
@@ -29,7 +30,10 @@ end
 
 --- Runs a uquery command with the given query.
 --- @param query string
+--- @return string[], number
 function M.uquery(query)
+	-- Note: We pass `enable_recording = true`, so we're always going to get
+	-- output here instead of `nil`.
 	return M.buck2({ "uquery", "--console", "simple", "--", query }):sync(4000)
 end
 

--- a/vim-plugins/buck2.nvim/plugin/buck2-plugin.lua
+++ b/vim-plugins/buck2.nvim/plugin/buck2-plugin.lua
@@ -1,34 +1,29 @@
+vim.api.nvim_create_user_command("BuckTarget", function()
+	local buck2 = require("jade.buck2")
+	local fullpath = vim.fn.expand("%:p")
 
-vim.api.nvim_create_user_command('BuckTarget', function()
-        local buck2 = require('jade.buck2')
-        local fullpath = vim.fn.expand('%:p')
+	local targets = buck2.uquery(('owner("%s")'):format(fullpath))
 
-        local targets = buck2.uquery(('owner("%s")'):format(fullpath))
+	print(table.concat(targets, "\n"))
+end, { nargs = 0 })
 
-        print(table.concat(targets, '\n'))
-    end,
-    { nargs = 0 })
+vim.api.nvim_create_user_command("BuckOpen", function()
+	local buck2 = require("jade.buck2")
+	local fullpath = vim.fn.expand("%:p")
 
-vim.api.nvim_create_user_command('BuckOpen', function()
-        local buck2 = require('jade.buck2')
-        local fullpath = vim.fn.expand('%:p')
-
-        local buckfiles = buck2.uquery(('buildfile(owner("%s"))'):format(fullpath))
-        if #buckfiles > 1 then
-            for _, f in ipairs(buckfiles) do
-                vim.api.nvim_exec2('split ' .. f, { output = false })
-            end
-        elseif #buckfiles == 1 then
-            vim.api.nvim_exec2('edit ' .. buckfiles[1], { output = false })
-        end
-    end,
-    { nargs = 0 })
+	local buckfiles = buck2.uquery(('buildfile(owner("%s"))'):format(fullpath))
+	if #buckfiles > 1 then
+		for _, f in ipairs(buckfiles) do
+			vim.api.nvim_exec2("split " .. f, { output = false })
+		end
+	elseif #buckfiles == 1 then
+		vim.api.nvim_exec2("edit " .. buckfiles[1], { output = false })
+	end
+end, { nargs = 0 })
 
 -- Telescope selector on targets in the file.
-vim.api.nvim_create_user_command('BuckOutline', function()
-        require('telescope.builtin').treesitter({
-            symbols = {'target'},
-        })
-    end,
-    { nargs = 0 })
-
+vim.api.nvim_create_user_command("BuckOutline", function()
+	require("telescope.builtin").treesitter({
+		symbols = { "target" },
+	})
+end, { nargs = 0 })


### PR DESCRIPTION
(Review as commits, or I can create stacked PRs.)

* `buck2.nvim`: `jade.buck2` -> `buck2`

  This makes `lazy.nvim` detect the "main" module name correctly, making
  this plugin spec load the plugin correctly:

      {
        "lf-/buck2.nvim",
        dependencies = {
          "nvim-lua/plenary.nvim",
        },
        -- Call `require("buck2").setup {}` to initialize the plugin:
        config = {},
      },

* `buck2.nvim`: move `plugin/buck2-plugin.lua` into `jade.buck2.setup()`

  This lets `lazy.nvim` initialize the plugin correctly by calling
  `jade.buck2.setup()`, and as a result (I think) hints to it that we need
  the `buck2.nvim` `lua` directory in the Lua module path.
