### PR TITLE
zsh: rename _git_resolve_args so it survives agent shell snapshots

### DIFF
--- a/configs/zsh/aliases.zsh
+++ b/configs/zsh/aliases.zsh
@@ -56,7 +56,13 @@ function removepath() {
 
 # Resolves // git-root-relative args. Populates _git_resolved_args array and
 # _git_resolved_print flag. Returns 1 (with error) if // is used outside a repo.
-function _git_resolve_args() {
+#
+# The double underscore is load-bearing: Claude Code snapshots the shell with
+# `typeset +f | grep -vE '^_[^_]'`, which drops single-underscore names on the
+# assumption that they are completion functions. cd/pushd below survive that
+# filter, so a single-underscore helper would leave them calling a function that
+# does not exist -- every cd in an agent shell dying with exit 127.
+function __git_resolve_args() {
     local _cmd=$1 _top; shift
     _git_resolved_args=() _git_resolved_print=0
     while [[ $# -gt 0 ]]; do
@@ -76,14 +82,14 @@ function _git_resolve_args() {
 
 function cd() {
     local _git_resolved_args _git_resolved_print
-    _git_resolve_args cd "$@" || return
+    __git_resolve_args cd "$@" || return
     (( _git_resolved_print )) && echo "cd ${_git_resolved_args[@]}"
     builtin cd "${_git_resolved_args[@]}"
 }
 
 function pushd() {
     local _git_resolved_args _git_resolved_print
-    _git_resolve_args pushd "$@" || return
+    __git_resolve_args pushd "$@" || return
     (( _git_resolved_print )) && echo "pushd ${_git_resolved_args[@]}"
     builtin pushd "${_git_resolved_args[@]}"
 }


### PR DESCRIPTION
Claude Code snapshots the login shell and sources that snapshot for every command it runs. It captures functions with `typeset +f | grep -vE '^_[^_]'`, which drops single-underscore names on the assumption that they are completion functions.

`cd` and `pushd` survived that filter; `_git_resolve_args`, which they call, did not. So every `cd` in an agent shell failed:

```
$ cd /tmp
cd:2: command not found: _git_resolve_args
$ echo $?
127
```

Worse than noisy: the call site is `_git_resolve_args cd "$@" || return`, so the directory never changed **and** the function returned 127 — silently killing any `cd foo && ...` chain an agent had written, and leaving it running in the wrong directory.

Renaming to `__git_resolve_args` puts the helper on the right side of that filter. A comment records why the double underscore is load-bearing.

## Verification

Reproduced Claude Code's capture procedure verbatim (`zsh -c -l`, same filter regex) against both revisions:

| | helper captured | `cd /tmp` |
|---|---|---|
| before | no | `cd:2: command not found: _git_resolve_args` |
| after | yes | `OK pwd=/tmp` |

And confirmed nothing else moved, running against the regenerated snapshot: `cd //configs` → resolves to git root and echoes the resolved path; `pushd //rules` → same; bare `cd` → home; `cd //nope` outside a repo → `cd: not inside a git repository`, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)